### PR TITLE
Update Rosiecord Plumpy iconpack

### DIFF
--- a/iconpacks/configs/rosiecord-plumpy.json
+++ b/iconpacks/configs/rosiecord-plumpy.json
@@ -1,3 +1,0 @@
-{
-  "biggerStatus": true
-}

--- a/iconpacks/list.json
+++ b/iconpacks/list.json
@@ -25,7 +25,7 @@
       },
       "suffix": "",
       "config": "https://raw.githubusercontent.com/Rairof/discord-iconpacks/master/Packs/Plumpy/rosiecord-plumpy.json",
-      "load": "https://raw.githubusercontent.com/rairof/discord-iconpacks/master/Packs/Plumpy/"
+      "load": "https://raw.githubusercontent.com/Rairof/discord-iconpacks/master/Packs/Plumpy/"
     },
     {
       "id": "rosiecord-iconsax",

--- a/iconpacks/list.json
+++ b/iconpacks/list.json
@@ -14,14 +14,18 @@
           {
             "name": "samara",
             "id": "1236648613145346203"
-          }
+          },
+          {
+            "name": "Rairof",
+            "id": "923212189123346483"
+          }          
         ],
         "source": "https://icons8.com/icons/plumpy",
         "sources": ["https://icons8.com/icons/plumpy"]
       },
-      "suffix": "@2x",
-      "config": "https://raw.githubusercontent.com/nexpid/VendettaThemesPlus/main/iconpacks/configs/rosiecord-plumpy.json",
-      "load": "https://raw.githubusercontent.com/acquitelol/rosiecord/master/Packs/Plumpy/"
+      "suffix": "",
+      "config": "https://raw.githubusercontent.com/Rairof/discord-iconpacks/master/Packs/Plumpy/rosiecord-plumpy.json",
+      "load": "https://raw.githubusercontent.com/rairof/discord-iconpacks/master/Packs/Plumpy/"
     },
     {
       "id": "rosiecord-iconsax",


### PR DESCRIPTION
Swap out rosiecord's plumpy link with rairof's fork (it's updated)