### PR TITLE
Update Iconsax source

### DIFF
--- a/iconpacks/list.json
+++ b/iconpacks/list.json
@@ -49,7 +49,7 @@
                 ]
             },
             "suffix": "@2x",
-            "load": "https://raw.githubusercontent.com/acquitelol/rosiecord/master/Packs/Iconsax/"
+            "load": "https://raw.githubusercontent.com/moodzz1/rosiecord/master/Packs/Iconsax/"
         },
         {
             "id": "md3",


### PR DESCRIPTION
Change Iconsax link to my fork, which has icons needed for Tabsv2 (since my PR isn't getting merged)